### PR TITLE
Adding "fluent setters" feature

### DIFF
--- a/ramler-itest/pom.xml
+++ b/ramler-itest/pom.xml
@@ -43,6 +43,7 @@
                     <model>${basedir}/src/test/resources/raml/inheritance.raml</model>
                     <jacksonTypeInfo>true</jacksonTypeInfo>
                     <jacksonPropertyName>true</jacksonPropertyName>
+                    <fluentSetterPrefix>with</fluentSetterPrefix>
                 </configuration>
                 <executions>
                     <execution>

--- a/ramler-itest/src/test/java/org/ops4j/ramler/itest/FluentSetterTest.java
+++ b/ramler-itest/src/test/java/org/ops4j/ramler/itest/FluentSetterTest.java
@@ -1,0 +1,35 @@
+package org.ops4j.ramler.itest;
+
+import org.junit.Test;
+import org.ops4j.ramler.itest.model.Employee;
+import org.ops4j.ramler.itest.model.Person;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that fluent setters are working
+ */
+public class FluentSetterTest {
+
+    @Test
+    public void testFluentSetters() {
+
+        Person person = new Person().withAge(12).withFirstname("My Firstname");
+        assertThat(person.getAge()).isEqualTo(12);
+        assertThat(person.getFirstname()).isEqualTo("My Firstname");
+
+        person.setFirstname("Changed Name");
+        assertThat(person.getFirstname()).isEqualTo("Changed Name");
+    }
+
+    /**
+     * Tests that inherited fields also properly accessible by fluent api
+     */
+    @Test
+    public void testFluentSettersForInherited() {
+
+        Employee employee = new Employee().withAge(12).withDepartment("My Department");
+        assertThat(employee.getAge()).isEqualTo(12);
+        assertThat(employee.getDepartment()).isEqualTo("My Department");
+    }
+}

--- a/ramler-java/src/main/java/org/ops4j/ramler/generator/Configuration.java
+++ b/ramler-java/src/main/java/org/ops4j/ramler/generator/Configuration.java
@@ -46,6 +46,8 @@ public class Configuration {
 
     private boolean jacksonPropertyName;
 
+    private String fluentSetterPrefix;
+
     /**
      * Gets the name of the base package for all subpackages created by the code generator.
      *
@@ -221,5 +223,24 @@ public class Configuration {
      */
     public void setJacksonPropertyName(boolean jacksonPropertyName) {
         this.jacksonPropertyName = jacksonPropertyName;
+    }
+
+    /**
+     * Whether fluent setters shall be generated
+     */
+    public boolean isFluentSetters() {
+        return fluentSetterPrefix != null;
+    }
+
+    /**
+     * Sets prefix for fluent setters
+     * @param fluentSetterPrefix Prefix or <code>null</code> (=default) if no fluent setters shall be generated
+     */
+    public void setFluentSetterPrefix(String fluentSetterPrefix) {
+        this.fluentSetterPrefix = fluentSetterPrefix;
+    }
+
+    public String getFluentSetterPrefix() {
+        return fluentSetterPrefix;
     }
 }

--- a/ramler-java/src/test/java/org/ops4j/ramler/generator/AbstractGeneratorTest.java
+++ b/ramler-java/src/test/java/org/ops4j/ramler/generator/AbstractGeneratorTest.java
@@ -48,17 +48,13 @@ public abstract class AbstractGeneratorTest {
     protected JDefinedClass klass;
     protected Set<String> methodNames;
     protected Set<String> fieldNames;
-    private JCodeModel codeModel;
+    protected JCodeModel codeModel;
     private JPackage apiPackage;
 
     @Before
     public void generateJavaModel() {
-        Configuration config = new Configuration();
-        config.setSourceFile(String.format("raml/%s.raml", getBasename()));
-        config.setBasePackage(String.format("org.ops4j.raml.%s", getBasename()));
-        config.setTargetDir(new File("target/generated/raml"));
 
-        generator = new Generator(config);
+        generator = new Generator(getConfiguration());
         generator.generate();
 
         codeModel = generator.getContext().getCodeModel();
@@ -67,6 +63,14 @@ public abstract class AbstractGeneratorTest {
     }
 
     public abstract String getBasename();
+
+    protected Configuration getConfiguration() {
+        Configuration config = new Configuration();
+        config.setSourceFile(String.format("raml/%s.raml", getBasename()));
+        config.setBasePackage(String.format("org.ops4j.raml.%s", getBasename()));
+        config.setTargetDir(new File("target/generated/raml"));
+        return config;
+    }
 
     protected void assertClasses(String... classNames) {
         assertThat(modelPackage.classes()).extracting(JDefinedClass::name)

--- a/ramler-java/src/test/java/org/ops4j/ramler/generator/FluentSetterTest.java
+++ b/ramler-java/src/test/java/org/ops4j/ramler/generator/FluentSetterTest.java
@@ -1,0 +1,115 @@
+package org.ops4j.ramler.generator;
+
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JFieldVar;
+import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JType;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests fluent setters
+ * @see Configuration#isFluentSetters()
+ */
+public class FluentSetterTest extends AbstractGeneratorTest {
+
+    @Test
+    public void shouldFindFluentSetters() {
+        expectClass("Person");
+        assertProperty(klass, "firstName", "String", "getFirstName", "setFirstName");
+        assertFluentSetter(klass,  "String", "withFirstName");
+
+        assertProperty(klass, "lastName", "String", "getLastName", "setLastName");
+        assertFluentSetter(klass,  "String", "withLastName");
+
+        assertProperty(klass, "duplicateProperty", "int", "getDuplicateProperty", "setDuplicateProperty");
+        assertFluentSetter(klass,  "int", "withDuplicateProperty");
+
+        // expect read only fields / getter available but that there is NO fluent setter
+        assertFieldAvailable("DISCRIMINATOR", "String");
+        assertGetterAvailable("getObjectType", "String");
+
+        verifyClass();
+    }
+
+    /**
+     * Tests that fluent setters will also be generated for inherited properties
+     */
+    @Test
+    public void shouldFindInheritedFluentSetters() {
+
+        expectClass("Employee");
+
+        // expect current fields to be added
+        assertProperty(klass, "employeeId", "int", "getEmployeeId", "setEmployeeId");
+        assertFluentSetter(klass, "int", "withEmployeeId");
+
+        assertProperty(klass, "colleagues", "List<Employee>", "getColleagues", "setColleagues");
+        assertFluentSetter(klass, "List<Employee>", "withColleagues");
+
+
+        // expect inherited fields to be added as well
+        assertFluentSetter(klass, "String", "withFirstName");
+        assertFluentSetter(klass, "String", "withLastName");
+        assertFluentSetter(klass,  "int", "withDuplicateProperty");
+
+        // expect read only fields / getter available but that there is NO fluent setter
+        assertFieldAvailable("DISCRIMINATOR", "String");
+        assertGetterAvailable("getObjectType", "String");
+
+        // expect duplicateProperty not to be listed again
+        verifyClass();
+    }
+
+    @Override
+    public String getBasename() {
+        return "fluentSetters";
+    }
+
+    @Override
+    protected Configuration getConfiguration() {
+        Configuration result = super.getConfiguration();
+        result.setFluentSetterPrefix("with");
+        return result;
+    }
+
+    /**
+     * Assert that there is a fluent setter for given property name
+     */
+    private void assertFluentSetter(JDefinedClass klass, String typeName, String methodName) {
+
+        List<JMethod> methods = klass.methods().stream().filter(m -> m.name().equals(methodName)).collect(toList());
+        assertThat(methods).hasSize(1);
+        JMethod method = methods.get(0);
+        
+        assertThat(method.type()).isEqualTo(klass);
+        assertThat(method.params().size()).isEqualTo(1);
+        assertThat(method.params().get(0).type().name()).isEqualTo(typeName);
+
+        methodNames.remove(methodName);
+    }
+
+    private void assertFieldAvailable(String fieldName, String typeName) {
+
+        JFieldVar field = klass.fields().get(fieldName);
+        assertThat(field).isNotNull();
+        assertThat(field.type().name()).isEqualTo(typeName);
+
+        fieldNames.remove(fieldName);
+    }
+
+    private void assertGetterAvailable(String getterMethodName, String typeName) {
+
+        List<JMethod> getters = klass.methods().stream().filter(m -> m.name().equals(getterMethodName)).collect(toList());
+        assertThat(getters).hasSize(1);
+        JMethod getter = getters.get(0);
+        assertThat(getter.type().name()).isEqualTo(typeName);
+        assertThat(getter.hasSignature(new JType[0])).isEqualTo(true);
+
+        methodNames.remove(getterMethodName);
+    }
+}

--- a/ramler-java/src/test/resources/raml/fluentSetters.raml
+++ b/ramler-java/src/test/resources/raml/fluentSetters.raml
@@ -1,0 +1,20 @@
+#%RAML 1.0
+title: Fluent Setters Test
+mediaType: application/json
+uses:
+  r: ../ramler.raml 
+types:
+  Person:
+    discriminator: objectType
+    properties:
+      objectType: string
+      duplicateProperty: integer
+      firstName: string
+      lastName: string
+  Employee:
+    type: Person
+    properties:
+      duplicateProperty: integer
+      employeeId: integer
+      colleagues: Employee[]
+

--- a/ramler-maven-plugin/src/main/java/org/ops4j/ramler/maven/AbstractJavaMojo.java
+++ b/ramler-maven-plugin/src/main/java/org/ops4j/ramler/maven/AbstractJavaMojo.java
@@ -76,6 +76,13 @@ public abstract class AbstractJavaMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean jacksonPropertyName;
 
+    /**
+     * A prefix (e.g. "with") to be used for fluent setter generation. If not set, then no fluent setters will
+     * be generated at all
+     */
+    @Parameter
+    private String fluentSetterPrefix;
+
     @Parameter(readonly = true, defaultValue = "${project}")
     protected MavenProject project;
 
@@ -97,6 +104,7 @@ public abstract class AbstractJavaMojo extends AbstractMojo {
             config.setInterfaceNameSuffix(interfaceNameSuffix);
             config.setJacksonTypeInfo(jacksonTypeInfo);
             config.setJacksonPropertyName(jacksonPropertyName);
+            config.setFluentSetterPrefix(fluentSetterPrefix);
 
             try {
                 Generator generator = new Generator(config);


### PR DESCRIPTION
If enabled (via switch #fluentSetterPrefix), for each property, a fluent setter like

  ThisTypeClass withProperty(PropertyType value)

will be generated in addition to #setProperty(PropertyType value)